### PR TITLE
Add the department and job title attributes to users.

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,22 @@ The connector schema is drawn from available variables in the Zoom User API and 
    </td>
   </tr>
   <tr>
+   <td>DEPT
+   </td>
+   <td>String
+   </td>
+   <td>The user's department.
+   </td>
+  </tr>
+  <tr>
+   <td>JOB_TITLE
+   </td>
+   <td>String
+   </td>
+   <td>The user's job title.
+   </td>
+  </tr>
+  <tr>
    <td>LANGUAGE
    </td>
    <td>String

--- a/src/main/java/com/exclamationlabs/connid/base/zoom/adapter/ZoomUsersAdapter.java
+++ b/src/main/java/com/exclamationlabs/connid/base/zoom/adapter/ZoomUsersAdapter.java
@@ -46,6 +46,8 @@ public class ZoomUsersAdapter extends BaseAdapter<ZoomUser, ZoomConfiguration> {
     result.add(new ConnectorAttribute(FIRST_NAME.name(), STRING));
     result.add(new ConnectorAttribute(LAST_NAME.name(), STRING));
     result.add(new ConnectorAttribute(Name.NAME, EMAIL.name(), STRING, REQUIRED));
+    result.add(new ConnectorAttribute(DEPT.name(), STRING));
+    result.add(new ConnectorAttribute(JOB_TITLE.name(), STRING));
 
     result.add(new ConnectorAttribute(PASSWORD.name(), STRING, NOT_UPDATEABLE));
     result.add(new ConnectorAttribute(LANGUAGE.name(), STRING));
@@ -97,6 +99,9 @@ public class ZoomUsersAdapter extends BaseAdapter<ZoomUser, ZoomConfiguration> {
           AdapterValueTypeConverter.getSingleAttributeValue(String.class, attributes, EMAIL));
     }
 
+    user.setDept(AdapterValueTypeConverter.getSingleAttributeValue(String.class, attributes, DEPT));
+    user.setJobTitle(AdapterValueTypeConverter.getSingleAttributeValue(String.class, attributes, JOB_TITLE));
+    
     user.setTimezone(
         AdapterValueTypeConverter.getSingleAttributeValue(String.class, attributes, TIME_ZONE));
 
@@ -199,6 +204,8 @@ public class ZoomUsersAdapter extends BaseAdapter<ZoomUser, ZoomConfiguration> {
     attributes.add(AttributeBuilder.build(TIME_ZONE.name(), user.getTimezone()));
 
     attributes.add(AttributeBuilder.build(TYPE.name(), user.getType()));
+    attributes.add(AttributeBuilder.build(DEPT.name(), user.getDept()));
+    attributes.add(AttributeBuilder.build(JOB_TITLE.name(), user.getJobTitle()));
     attributes.add(AttributeBuilder.build(PHONE_NUMBER.name(), user.getPhoneNumber()));
     attributes.add(AttributeBuilder.build(PHONE_COUNTRY.name(), user.getPhoneCountry()));
     attributes.add(AttributeBuilder.build(CREATED_AT.name(), user.getCreatedAt()));

--- a/src/main/java/com/exclamationlabs/connid/base/zoom/attribute/ZoomUserAttribute.java
+++ b/src/main/java/com/exclamationlabs/connid/base/zoom/attribute/ZoomUserAttribute.java
@@ -22,6 +22,8 @@ public enum ZoomUserAttribute {
   FIRST_NAME,
   LAST_NAME,
   EMAIL,
+  DEPT,
+  JOB_TITLE,
   PASSWORD,
   LANGUAGE,
   TIME_ZONE,

--- a/src/main/java/com/exclamationlabs/connid/base/zoom/model/ZoomUser.java
+++ b/src/main/java/com/exclamationlabs/connid/base/zoom/model/ZoomUser.java
@@ -24,7 +24,7 @@ public class ZoomUser implements IdentityModel {
 
   @SerializedName("created_at")
   private String createdAt;
-
+  private String dept;
   private String email;
   private ZoomFeature feature;
 
@@ -37,6 +37,8 @@ public class ZoomUser implements IdentityModel {
   private transient Set<String> groupsToAdd;
   private transient Set<String> groupsToRemove;
   private String id;
+  @SerializedName("job_title")
+  private String jobTitle;
   private transient ZoomPhoneUserProfile outboundAdd;
   private transient ZoomPhoneUserProfile outboundRemove;
   private String language;
@@ -67,6 +69,10 @@ public class ZoomUser implements IdentityModel {
 
   public String getCreatedAt() {
     return createdAt;
+  }
+  
+  public String getDept() {
+    return dept;
   }
 
   public String getEmail() {
@@ -105,6 +111,10 @@ public class ZoomUser implements IdentityModel {
   @Override
   public String getIdentityNameValue() {
     return getEmail();
+  }
+  
+  public String getJobTitle() {
+    return jobTitle;
   }
 
   public ZoomPhoneUserProfile getOutboundAdd() {
@@ -170,6 +180,10 @@ public class ZoomUser implements IdentityModel {
   public void setCreatedAt(String createdAt) {
     this.createdAt = createdAt;
   }
+  
+  public void setDept(String dept) {
+    this.dept = dept;
+  }
 
   public void setEmail(String email) {
     this.email = email;
@@ -199,6 +213,10 @@ public class ZoomUser implements IdentityModel {
     this.id = id;
   }
 
+  public void setJobTitle(String jobTitle) {
+    this.jobTitle = jobTitle;
+  }
+  
   public void setOutboundAdd(ZoomPhoneUserProfile outboundAdd) {
     this.outboundAdd = outboundAdd;
   }


### PR DESCRIPTION
Fixes #24 

This makes the department and job title attributes something that can be managed. Right now there is now way in Zoom to prevent a user from changing these values. But will help keeps things consistent in the directory.