### PR TITLE
Update to handle disabled users in a variety of ways.

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,30 @@ The configuration parameters are specified in the following table. One thing to 
    <td>When this value is true the user will be immediately logged out when a deactivate event occurs. 
    </td>
   </tr>
+  <tr>
+    <td>Ignore Update Error On Disabled User
+    </td>
+    <td>no
+    </td>
+    <td>When this value is <strong>true</strong> the connector won't return errors when trying to update a disabled user. This means that disabled users will remain out of sync, but actions won't cause errors to be returned. When this value is <strong>false</strong> (default), any updates performed on disabled users will result in errors.
+    </td>
+  </tr>
+  <tr>
+    <td>Remove Phone Feature On Disabled User
+    </td>
+    <td>no
+    </td>
+    <td>When this value is <strong>true</strong> the connector will remove the phone feature from disabled users when <strong>ZOOM_PHONE_FEATURE</strong> is set to <strong>false</strong>. This is done by temporarily enabling the user, performing that and any other updates, then disabling the user again. When this value is <strong>false</strong> (default), any attempted changes at changing <strong>ZOOM_PHONE_FEATURE</strong> on a disabled user will result in an error.
+    </td>
+  </tr>
+  <tr>
+    <td>Update Disabled Users
+    </td>
+    <td>no
+    </td>
+    <td>When this value is <strong>true</strong> the connector will update user information on disabled users, including the <strong>ZOOM_PHONE_FEATURE</strong>. This is done by temporarily enabling the user, performing the update, then disabling the user again. When this value is <strong>false</strong> (default), any attempted changes at chaging attributes on a disabled user will result in an error.
+    </td>
+  </tr>
 </table>
 
 

--- a/configuration.structure.yml
+++ b/configuration.structure.yml
@@ -42,4 +42,22 @@ custom:
           default: 'false'
           display: 'Entitlement Deletion Enabled'
           help: 'Enables the connector''s group deletion capability allowing the automated removal of Zoom groups via the Zoom API. The group removal capability is disabled by default.'
+      ignoreUpdateErrorOnDisabledUser:
+        type: boolean
+        order: 3060
+        default: 'false'
+        display: 'Ignore Error on Disabled User'
+        help: 'Ignores update errors on disabled users, as they can''t be updated. Phone feature will still cause errors to be thrown.'
+      removePhoneFeatureOnDisabledUser:
+        type: boolean
+        order: 3070
+        default: 'false'
+        display: 'Remove Phone Feature on Disabled User'
+        help: 'Removes the Phone feature on disabled users by temporarily reenabling them. Other updates may fire at the time.'
+      updateDisabledUsers:
+        type: boolean
+        order: 3080
+        default: 'false'
+        display: 'Update Disabled Users'
+        help: 'Updates information on disabled users by temporarily reenabling them.'
 

--- a/src/main/java/com/exclamationlabs/connid/base/zoom/driver/rest/UserDisabledException.java
+++ b/src/main/java/com/exclamationlabs/connid/base/zoom/driver/rest/UserDisabledException.java
@@ -1,12 +1,9 @@
 /*
     Copyright 2020 Exclamation Labs
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
-
         http://www.apache.org/licenses/LICENSE-2.0
-
     Unless required by applicable law or agreed to in writing, software
     distributed under the License is distributed on an "AS IS" BASIS,
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,18 +11,12 @@
     limitations under the License.
 */
 
-package com.exclamationlabs.connid.base.zoom.model.response.fault;
+package com.exclamationlabs.connid.base.zoom.driver.rest;
 
-public interface ErrorResponseCode {
-  int PAID_SUBSCRIPTION_REQUIRED = 200;
-  int VALIDATION_FAILED = 300;
+import org.identityconnectors.framework.common.exceptions.ConnectorException;
 
-  int USER_NOT_FOUND = 1001;
-  int USER_ALREADY_EXISTS = 1005;
-  int USER_DISABLE = 1053;
-  int REQUIRES_MANAGED_DOMAIN = 1116;
-
-  int GROUP_NOT_FOUND = 4130;
-  int GROUP_NAME_ALREADY_EXISTS = 4132;
-  int TOKEN_EXPIRED = 124;
+public class UserDisabledException extends ConnectorException {
+  public UserDisabledException(String message) {
+    super(message);
+  }
 }

--- a/src/main/java/com/exclamationlabs/connid/base/zoom/driver/rest/ZoomFaultProcessor.java
+++ b/src/main/java/com/exclamationlabs/connid/base/zoom/driver/rest/ZoomFaultProcessor.java
@@ -92,7 +92,8 @@ public class ZoomFaultProcessor implements RestFaultProcessor {
     switch (faultData.getCode()) {
       case PAID_SUBSCRIPTION_REQUIRED:
         throw new PaidAccountRequiredException(faultData.getMessage());
-
+      case USER_DISABLE:
+        throw new UserDisabledException(faultData.getMessage());
       case USER_NOT_FOUND:
       case GROUP_NOT_FOUND:
         return false;
@@ -116,20 +117,4 @@ public class ZoomFaultProcessor implements RestFaultProcessor {
     return true;
   }
 
-  private Boolean checkRecognizedFaultMessages(ErrorResponse faultData) {
-    if (faultData != null
-        && faultData.getMessage() != null
-        && (!faultData.getMessage().isEmpty())) {
-      String message = faultData.getMessage();
-      if (message.contains("User does not exist")) {
-        Logger.info(this, message);
-        return true;
-      } else {
-        Logger.error(this, message);
-        throw new ConnectorException(
-            "Unhandled Exception Received from Zoom.  Message: " + faultData.getMessage());
-      }
-    }
-    return false;
-  }
 }


### PR DESCRIPTION
Instead of just throwing exceptions and causing errors in the tasks.

Fixes #25 

We do delayed delete, so Zoom accounts stick around for a while. I believe that disabled Zoom Phone still counts as a license, so we want to remove that license (and free up that phone number) on disabled users. My disable user and disable Zoom phone processes almost always run at different times. Removal of the Zoom Phone feature removes all of the other pieces, so just caring about the feature is sufficient. I also have the issue that other user info can change after they have been disabled. So I added two options for that: ignore or fire the updates. With everything set to the default of false, the behavior of the connector doesn't change.